### PR TITLE
speed up peep with caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,18 @@
 FROM mozillamarketplace/centos-mysql-mkt:0.2
 RUN yum install -y supervisor bash-completion && yum clean all
 
-# Ship the source in the container.
-COPY . /srv/payments-service
+# Copy requirements over first to cache peep install.
+COPY requirements /srv/payments-service/requirements
 
 RUN pip install --find-links https://pyrepo.addons.mozilla.org/ peep
 # TODO: add caching when available. https://github.com/erikrose/peep/issues/93
 RUN peep install \
     --no-deps -r /srv/payments-service/requirements/dev.txt \
     --find-links https://pyrepo.addons.mozilla.org/
+
+
+# Ship the source in the container.
+COPY . /srv/payments-service
 
 EXPOSE 8000
 


### PR DESCRIPTION
first run:

```
docker build -t payments-service/temp .  0.17s user 0.16s system 0% cpu 49.509 total
```

subsequent runs:

```
docker build -t payments-service/temp .  0.16s user 0.08s system 13% cpu 1.802 total
docker build -t payments-service/temp .  0.15s user 0.05s system 12% cpu 1.645 total
```
