### PR TITLE
pass through query dict

### DIFF
--- a/payments_service/braintree/tests/test_views.py
+++ b/payments_service/braintree/tests/test_views.py
@@ -174,12 +174,19 @@ class TestWebhook(TestCase):
 
     def test_verify(self):
         self.solitude.braintree.webhook.get.return_value = 'token'
-        res = self.client.get(reverse('braintree:webhook'))
+        res = self.client.get(reverse('braintree:webhook') + '?bt_challenge=f')
+        self.solitude.braintree.webhook.get.assert_called_with(
+            bt_challenge='f')
         eq_(res['Content-Type'], 'text/plain; charset=utf-8')
         eq_(res.status_code, 200)
         eq_(res.content, 'token')
 
     def test_parse(self):
         self.solitude.braintree.webhook.post.return_value = ''
-        res = self.client.post(reverse('braintree:webhook'))
+        res = self.client.post(
+            reverse('braintree:webhook'),
+            {'bt_payload': 'p', 'bt_signature': 's'}
+        )
+        self.solitude.braintree.webhook.post.assert_called_with(
+            {'bt_payload': ['p'], 'bt_signature': ['s']})
         eq_(res.status_code, 200)

--- a/payments_service/braintree/views.py
+++ b/payments_service/braintree/views.py
@@ -130,7 +130,3 @@ class Webhook(UnprotectedAPIView, SolitudeBodyguard):
             return (renderer, renderer.media_type)
         return (super(self.__class__, self)
                 .perform_content_negotiation(request, **kw))
-
-    def get(self, request, **kw):
-        return super(self.__class__, self).get(
-            request, **dict(request.QUERY_PARAMS.items()))


### PR DESCRIPTION
- the change in the underlying SolitudeBodyguard passed through the request, so the override is no longer needed
- the tests didn't actually test passing a query string, so beefed them up a bit
