### PR TITLE
Don't allow repeat payments with override

### DIFF
--- a/payments_service/braintree/tests/test_views.py
+++ b/payments_service/braintree/tests/test_views.py
@@ -198,15 +198,6 @@ class TestSubscribe(AuthenticatedTestCase):
         self.assert_form_error(res, ['__all__'])
         assert self.solitude.braintree.mozilla.subscription.get.called
 
-    def test_can_do_repeat_payments_with_setting(self):
-        self.setup_generic_buyer()
-        self.setup_existing_subscription()
-        self.expect_new_pay_method()
-
-        with self.settings(ALLOW_REPEAT_PAYMENTS=True):
-            res, data = self.post()
-        eq_(res.status_code, 204, res)
-
 
 class TestWebhook(TestCase):
 

--- a/payments_service/braintree/views.py
+++ b/payments_service/braintree/views.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
 from rest_framework.views import APIView
@@ -60,26 +59,23 @@ class Subscriptions(APIView):
         if not form.is_valid():
             return error_400(response=form.errors)
 
-        if settings.ALLOW_REPEAT_PAYMENTS:
-            log.warn('not protecting against repeat subscriptions')
-        else:
-            # TODO: remove this after
-            # https://github.com/mozilla/solitude/issues/466
-            product = self.api.generic.product.get_object_or_404(
-                public_id=form.cleaned_data['plan_id'],
-            )
-            # Check if the user is already subscribed to this plan.
-            result = self.api.braintree.mozilla.subscription.get(
-                paymethod__braintree_buyer__buyer=self.request.user.pk,
-                seller_product=product['resource_pk'],
-            )
-            if len(result):
-                log.info(
-                    'buyer {buyer} is already subscribed to product {product}'
-                    .format(buyer=self.request.user.pk,
-                            product=product['resource_pk']))
-                return error_400(
-                    response='user is already subscribed to this product')
+        # TODO: remove this after
+        # https://github.com/mozilla/solitude/issues/466
+        product = self.api.generic.product.get_object_or_404(
+            public_id=form.cleaned_data['plan_id'],
+        )
+        # Check if the user is already subscribed to this plan.
+        result = self.api.braintree.mozilla.subscription.get(
+            paymethod__braintree_buyer__buyer=self.request.user.pk,
+            seller_product=product['resource_pk'],
+        )
+        if len(result):
+            log.info(
+                'buyer {buyer} is already subscribed to product {product}'
+                .format(buyer=self.request.user.pk,
+                        product=product['resource_pk']))
+            return error_400(
+                response='user is already subscribed to this product')
 
         try:
             self.set_up_customer(request.user)

--- a/payments_service/settings/base.py
+++ b/payments_service/settings/base.py
@@ -199,8 +199,3 @@ SOLITUDE_SECRET = 'please change this'
 # Firefox Accounts OAuth server to use.
 # https://github.com/mozilla/fxa-oauth-server/
 FXA_OAUTH_URL = 'https://oauth-stable.dev.lcip.org'
-
-# When True we won't complain if a user tries to buy the same thing twice.
-# This might be useful to enable during development if you want to keep
-# firing off payments in the sandbox.
-ALLOW_REPEAT_PAYMENTS = bool(os.environ.get('ALLOW_REPEAT_PAYMENTS', False))


### PR DESCRIPTION
This just feels like a recipe for disaster, there could be lots of data inconsistencies.
There is now a better approach of clearing data with a reset script in
https://github.com/mozilla/solitude/pull/471
