### PR TITLE
add in a filtered email backend

### DIFF
--- a/docs/topics/contributing.rst
+++ b/docs/topics/contributing.rst
@@ -11,6 +11,21 @@ Installation is done through `docker compose`_ from `payments-env`_
 but this process is currently in flux. This section will be updated
 when the dust settles.
 
+Sending email
+=============
+
+To send email set the ``SERVICE_EMAIL_*`` settings that match the `Django settings`_ in your environment. For example::
+
+    export SERVICE_EMAIL_HOST=your.server.com
+
+To avoid sending email to everyone, use a filtered email backend::
+
+    export SERVICE_EMAIL_BACKEND=payments_service.base.email.FilteredEmailBackend
+
+This will read the ``EMAIL_ALLOWED_LIST`` setting and only send email to emails in that list. By default that is::
+
+    EMAIL_ALLOWED_LIST = ['.*@mozilla\.com$']
+
 Running Tests
 =============
 
@@ -25,5 +40,6 @@ You can submit bug reports and patches at
 https://github.com/mozilla/payments-service/
 
 
+.. _`Django settings`: https://docs.djangoproject.com/en/1.8/ref/settings/#email-host
 .. _`docker compose`: http://docs.docker.com/compose/
 .. _`payments-env`: https://github.com/mozilla/payments-env

--- a/payments_service/base/email.py
+++ b/payments_service/base/email.py
@@ -1,0 +1,48 @@
+import logging
+import re
+
+from django.conf import settings
+from django.core.mail.backends import locmem
+from django.core.mail.backends import smtp
+
+log = logging.getLogger(__name__)
+
+
+def allowed(email_messages):
+    for email_message in email_messages:
+        for recipient in email_message.recipients():
+            if not settings.EMAIL_ALLOWED_LIST:
+                # No explicit list of emails was given.
+                return True
+
+            for regex in settings.EMAIL_ALLOWED_LIST:
+                # If the regex matched allow the email to be sent.
+                if re.match(regex, recipient):
+                    break
+
+            else:
+                log.warning(u'Email: {} did not match a regex in the '
+                            u'EMAIL_ALLOWED_LIST. Email not sent.'
+                            .format(recipient))
+                return False
+
+    return True
+
+
+class FilteredEmailBackend(smtp.EmailBackend):
+
+    def send_messages(self, email_messages):
+        if allowed(email_messages):
+            return (super(FilteredEmailBackend, self)
+                    .send_messages(email_messages))
+        return False
+
+
+# Used for tests.
+class FilteredLocEmailBackend(locmem.EmailBackend):
+
+    def send_messages(self, email_messages):
+        if allowed(email_messages):
+            return (super(FilteredLocEmailBackend, self)
+                    .send_messages(email_messages))
+        return False

--- a/payments_service/base/tests/test_backend.py
+++ b/payments_service/base/tests/test_backend.py
@@ -1,0 +1,36 @@
+from django.core import mail
+from django.test.utils import override_settings
+
+from nose.tools import eq_
+
+from payments_service.base.tests import TestCase
+
+filtered = 'payments_service.base.email.FilteredLocEmailBackend'
+
+
+@override_settings(EMAIL_BACKEND=filtered)
+class TestAllowedToEmail(TestCase):
+
+    def send(self, recipients):
+        mail.send_mail('subject', 'msg', 'a@m.o', recipients,
+                       fail_silently=False)
+
+    @override_settings(EMAIL_ALLOWED_LIST=[])
+    def test_no_list(self):
+        self.send(['a@m.c'])
+        eq_(len(mail.outbox), 1)
+
+    @override_settings(EMAIL_ALLOWED_LIST=['a@m.c'])
+    def test_allowed(self):
+        self.send(['a@m.c'])
+        eq_(len(mail.outbox), 1)
+
+    @override_settings(EMAIL_ALLOWED_LIST=['a@m.c'])
+    def test_not_allowed(self):
+        self.send(['a@m.o'])
+        eq_(len(mail.outbox), 0)
+
+    @override_settings(EMAIL_ALLOWED_LIST=['a@m.c'])
+    def test_multiple(self):
+        self.send(['a@m.o', 'a@m.c'])
+        eq_(len(mail.outbox), 0)

--- a/payments_service/settings/base.py
+++ b/payments_service/settings/base.py
@@ -91,8 +91,25 @@ DATABASES = {
 }
 
 # Only write emails to the console during development.
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+#
+# You can set the email variables in your environment to send real email.
+EMAIL_BACKEND = os.environ.get(
+    'SERVICE_EMAIL_BACKEND',
+    'django.core.mail.backends.console.EmailBackend'
+)
 
+EMAIL_HOST = os.environ.get('SERVICE_EMAIL_HOST', '')
+EMAIL_HOST_USER = os.environ.get('SERVICE_EMAIL_HOST_USER', '')
+EMAIL_HOST_PASSWORD = os.environ.get('SERVICE_EMAIL_HOST_PASSWORD', '')
+
+# Not negotiable.
+EMAIL_USE_TLS = True
+
+# A list of regex's that we will allow emails too. If empty then
+# emails will be sent to all address.
+#
+# This is not checked when the EMAIL_BACKEND is to console.
+EMAIL_ALLOWED_LIST = ['.*@mozilla\.com$']
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
@@ -107,12 +124,10 @@ USE_L10N = True
 
 USE_TZ = True
 
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
 STATIC_URL = '/static/'
-
 
 REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
@@ -179,7 +194,6 @@ LOGGING = {
     }
 }
 
-
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 NOSE_ARGS = [
@@ -190,7 +204,6 @@ NOSE_ARGS = [
 ]
 
 UNDER_TEST = os.environ.get('UNDER_TEST') == '1'
-
 
 # URL to private payment processor. https://github.com/mozilla/solitude/
 SOLITUDE_URL = os.environ.get('SOLITUDE_URL', 'http://solitude:2602')


### PR DESCRIPTION
- see also mozilla/payments-env#37
- allow SMTP servers to work and be setup from the env
- by default allow mozilla.com emails to work, but block everyone else
