### PR TITLE
Cannot patch other buyers' paymethods (fixes #95)

### DIFF
--- a/payments_service/solitude/__init__.py
+++ b/payments_service/solitude/__init__.py
@@ -37,7 +37,7 @@ class SolitudeBodyguard(APIView):
     # resource = 'services.status'
     resource = None
 
-    def replace_call_args(self, django_request, args, kw):
+    def replace_call_args(self, django_request, method, args, kw):
         """
         Optional hook to replace the arguments before executing the
         slumber callable.
@@ -46,6 +46,11 @@ class SolitudeBodyguard(APIView):
 
         *django_request*
             Original Django request object.
+
+        *method*
+            Effective request method. This might be different
+            than django_request.method in the case where one method
+            handler makes sub-requests.
 
         *args*
             Original slumber API call arguments.
@@ -87,7 +92,8 @@ class SolitudeBodyguard(APIView):
         api_request = getattr(self._resource(pk=resource_pk), method)
 
         # Allow this view to replace call args if it wants to.
-        args, kw = self.replace_call_args(django_request, args, kw)
+        args, kw = self.replace_call_args(django_request, method.lower(),
+                                          args, kw)
 
         log.info('solitude: about to request '
                  '{resource}{instance}.{method}{args}{kw}'

--- a/payments_service/solitude/tests/test.py
+++ b/payments_service/solitude/tests/test.py
@@ -94,7 +94,7 @@ class TestSolitudeBodyguard(AuthenticatedTestCase, WithDynamicEndpoints):
             methods = ['get']
             resource = 'services.status'
 
-            def replace_call_args(self, django_request, args, kw):
+            def replace_call_args(self, django_request, method, args, kw):
                 return new_args, new_kw
 
         self.endpoint(Replacer)


### PR DESCRIPTION
feels a bit ugly but this did fix a legit bug where paymethods were not filtered by buyer
