### PR TITLE
Separate out docs so that m2crypto isn't installed

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,6 +3,7 @@
 # foo==1.2.3 and you list all dependencies explicitly.
 
 -r prod.txt
+-r docs.txt
 
 # For testing.
 
@@ -36,45 +37,3 @@ pep8==1.5.7
 
 # sha256: rEVxaVwQzhU2vNuhopS58tPmzJ0OoXG2fVCghkzj4EI
 pyflakes==0.8.1
-
-
-# For documentation.
-
-# sha256: BwPB6lpq8LttDOwkcIMBM0lJ1W68f5XGQCjZxm-djV0
-alabaster==0.7.3
-
-# sha256: nwLQNXGE3h8JPBABK1LnRUoQCL5qXBhat6Mwes6x0S4
-babel==1.3
-
-# sha256: rkt0OyT9AsmZlDoV8BSzl2KoeKmdk38QK_aBpINhP6M
-# pyrepo wheelhouse
-# sha256: hqLub_0EQ5pN84W3f9gBV8bSw6WMpFYTg5k1X1qFhLw
-docutils==0.12
-
-# sha256: LiSsXQBNtXFJdqBKwOgMbfbkfpjDVMssDYL4h51Pj9s
-# pyrepo wheelhouse
-# sha256: env3jD-6yi2M8FBTgu0BW-7cqvxJsDYxrSLCC3dOfEE
-Jinja2==2.7.3
-
-# sha256: RDoLYzhx6Cc4e8xA4mqZdKbsmJHjZWRUOPBsszhuv2Q
-# pyrepo wheelhouse
-# sha256: AmqgFlcXzLuHsU8YgcVXEp7PXxDKLEAQUP5rnc-eKOk
-MarkupSafe==0.23
-
-# sha256: NYsFoMJgXBXPgzfRcBbrla_qrQfJAN-cLN524hlKklg
-pytz==2015.2
-
-# sha256: QYqTw5en7asj5ViNvAZ6x0pyPts9VBvUk295R252Rdo
-six==1.9.0
-
-# sha256: FcW-zVBL1OnVt8BieEaXBrtZ343SoriwJ4D0wUgL7_4
-snowballstemmer==1.1.0
-
-# sha256: Ld8Y2jsGIfpD_uS3KQ2grnibRvuJkniorMzaGVxJeac
-Sphinx==1.3.1
-
-# sha256: qKLiOalzG2hcfepiSF3sgc7zYB6-UKd6lalr3yl6-_c
-sphinx-rtd-theme==0.1.7
-
-# sha256: alM5uT6s8XI2Wnzex-CtWm5YNJ_BNu9umUx0nKXGG6c
-sphinxcontrib-httpdomain==1.3.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,42 @@
+# Documentation building requirements go here.
+# Be sure that you always specify an exact version such as:
+# foo==1.2.3 and you list all dependencies explicitly.
+
+# sha256: BwPB6lpq8LttDOwkcIMBM0lJ1W68f5XGQCjZxm-djV0
+alabaster==0.7.3
+
+# sha256: nwLQNXGE3h8JPBABK1LnRUoQCL5qXBhat6Mwes6x0S4
+babel==1.3
+
+# sha256: rkt0OyT9AsmZlDoV8BSzl2KoeKmdk38QK_aBpINhP6M
+# pyrepo wheelhouse
+# sha256: hqLub_0EQ5pN84W3f9gBV8bSw6WMpFYTg5k1X1qFhLw
+docutils==0.12
+
+# sha256: LiSsXQBNtXFJdqBKwOgMbfbkfpjDVMssDYL4h51Pj9s
+# pyrepo wheelhouse
+# sha256: env3jD-6yi2M8FBTgu0BW-7cqvxJsDYxrSLCC3dOfEE
+Jinja2==2.7.3
+
+# sha256: RDoLYzhx6Cc4e8xA4mqZdKbsmJHjZWRUOPBsszhuv2Q
+# pyrepo wheelhouse
+# sha256: AmqgFlcXzLuHsU8YgcVXEp7PXxDKLEAQUP5rnc-eKOk
+MarkupSafe==0.23
+
+# sha256: NYsFoMJgXBXPgzfRcBbrla_qrQfJAN-cLN524hlKklg
+pytz==2015.2
+
+# sha256: QYqTw5en7asj5ViNvAZ6x0pyPts9VBvUk295R252Rdo
+six==1.9.0
+
+# sha256: FcW-zVBL1OnVt8BieEaXBrtZ343SoriwJ4D0wUgL7_4
+snowballstemmer==1.1.0
+
+# sha256: Ld8Y2jsGIfpD_uS3KQ2grnibRvuJkniorMzaGVxJeac
+Sphinx==1.3.1
+
+# sha256: qKLiOalzG2hcfepiSF3sgc7zYB6-UKd6lalr3yl6-_c
+sphinx-rtd-theme==0.1.7
+
+# sha256: alM5uT6s8XI2Wnzex-CtWm5YNJ_BNu9umUx0nKXGG6c
+sphinxcontrib-httpdomain==1.3.0


### PR DESCRIPTION
Specifically, m2secret depends on M2Crypto but
RTD doesn't allow you to install with `--no-deps`
