### PR TITLE
fix up seller email

### DIFF
--- a/payments_service/braintree/templates/braintree/emails/subscription_base.html
+++ b/payments_service/braintree/templates/braintree/emails/subscription_base.html
@@ -12,7 +12,7 @@
       <div id="wrapper">
         <div class="header">
           <div id="logo" style="background-image: url({{ product.img }});"></div>
-          <h1>{{ seller.name.en }}</h1>
+          <h1>{{ seller.name }}</h1>
           <p class="user-email">{{ seller.email }}</p>
         </div>
         <div class="main">

--- a/payments_service/braintree/templates/braintree/emails/subscription_canceled.html
+++ b/payments_service/braintree/templates/braintree/emails/subscription_canceled.html
@@ -1,5 +1,5 @@
 {% extends 'braintree/emails/subscription_base.html' %}
-{% block info %}
+{% block main %}
     <div class="banner disabled">Subscription cancelled</div>
 
     <table>

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -56,8 +56,8 @@ oauthlib==0.7.2
 # sha256: PWMqzIaGoHullsTeJTJxG3s2D4jECiiIE5WqIUn718g
 oauth2==1.5.211
 
-# sha256: jvMK5LLSNmbmzADT1pZl6W6mfir4f09zkvWi2jvjcvo
-payments-config==0.0.8
+# sha256: O7dll_0Xuq0ER-6Ribo6j1PUuXgU7q62DLm4Thr3Hds
+payments-config==0.0.10
 
 # sha256: mG9LKd89WZeR-lvFXoRs6fY-q8fm8ZsrNNb0mPCdqQ8
 pyasn1==0.1.8


### PR DESCRIPTION
- looks like the seller.email got added prematurely
- this uses 0.0.10 of payments-config, which reverse the .en stuff
- update cancelled to use `main` not `info`
