### PR TITLE
Set up a Braintree customer on sign-in

### DIFF
--- a/payments_service/braintree/tests/test_views.py
+++ b/payments_service/braintree/tests/test_views.py
@@ -298,37 +298,6 @@ class TestSubscribe(AuthenticatedTestCase):
         }
         return pay_method_uri
 
-    def test_with_existing_customer(self):
-        buyer_pk = self.setup_generic_buyer()
-        self.setup_no_subscription_yet()
-        self.expect_new_pay_method()
-
-        res, data = self.post()
-        eq_(res.status_code, 204, res)
-
-        (self.solitude.braintree.mozilla.buyer.get_object_or_404
-         .assert_called_with(buyer=buyer_pk))
-        assert not self.solitude.braintree.customer.post.called
-
-        self.solitude.braintree.paymethod.post.assert_called_with({
-            'buyer_uuid': self.buyer_uuid,
-            'nonce': self.nonce,
-        })
-
-    def test_with_new_customer(self):
-        self.setup_generic_buyer()
-        self.setup_no_subscription_yet()
-        self.expect_new_pay_method()
-
-        # Set up non-existing braintree customer.
-        self.solitude.braintree.mozilla.buyer.get_object_or_404.side_effect = (
-            ObjectDoesNotExist)
-
-        res, data = self.post()
-        eq_(res.status_code, 204, res)
-
-        assert self.solitude.braintree.customer.post.called
-
     def test_with_new_pay_method(self):
         self.setup_generic_buyer()
         self.setup_no_subscription_yet()

--- a/payments_service/braintree/views.py
+++ b/payments_service/braintree/views.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.http import HttpResponse
 from django.template import Context
@@ -189,7 +188,6 @@ class Subscriptions(APIView):
                 response='user is already subscribed to this product')
 
         try:
-            self.set_up_customer(request.user)
             pay_method_uri = self.get_pay_method(
                 request.user,
                 form.cleaned_data['pay_method_uri'],
@@ -219,17 +217,6 @@ class Subscriptions(APIView):
                      .format(b=buyer.uuid, m=pay_method_uri))
 
         return pay_method_uri
-
-    def set_up_customer(self, buyer):
-        try:
-            self.api.braintree.mozilla.buyer.get_object_or_404(
-                buyer=buyer.pk)
-            log.info('using existing braintree customer tied to buyer {b}'
-                     .format(b=buyer))
-        except ObjectDoesNotExist:
-            log.info('creating new braintree customer for {buyer}'
-                     .format(buyer=buyer.pk))
-            self.api.braintree.customer.post({'uuid': buyer.uuid})
 
 
 class ChangeSubscriptionPayMethod(APIView):


### PR DESCRIPTION
Pretty much everything needs a Braintree customer
so we need to do it as soon as the user signs in.
