### PR TITLE
Add endpoint for getting user transactions

### DIFF
--- a/docs/topics/api.rst
+++ b/docs/topics/api.rst
@@ -361,7 +361,6 @@ These endpoints allow you to work with Braintree plan subscriptions.
     :status 200: subscriptions returned successfully
 
 .. _`solitude subscriptions`: http://solitude.readthedocs.org/en/latest/topics/braintree.html#get--braintree-mozilla-subscription--subscription%20id--
-.. _`generic product object`: http://solitude.readthedocs.org/en/latest/topics/generic.html#product
 
 .. http:post:: /api/braintree/subscriptions/
 
@@ -421,6 +420,66 @@ These endpoints allow you to work with Braintree plan subscriptions.
 
 .. _`subscription`: http://solitude.readthedocs.org/en/latest/topics/braintree.html#subscriptions
 
+
+Transactions
+~~~~~~~~~~~~~
+
+These endpoints allow you to work with Braintree transactions.
+
+.. http:get:: /api/braintree/transactions/
+
+    Get all transactions for the currently signed in user.
+
+    :>json array transactions:
+        array of solitude transactions with the `transaction` attribute
+        expanded to the `braintree transaction object`_ and the
+        `seller_product` attribute expanded to the `generic product object`_.
+
+    Example:
+
+    .. code-block:: json
+
+        {
+            "transactions": [
+                {
+                    "id": 1,
+                    "resource_pk": 1,
+                    "resource_uri": "/braintree/mozilla/transaction/1/",
+                    "created": "2015-08-07T14:53:23.966",
+                    "modified": "2015-08-07T14:53:23.966",
+                    "kind": "subscription_charged_successfully",
+                    "transaction": {
+                        "resource_pk": 1,
+                        "resource_uri": "/generic/transaction/1/"
+                        "seller_product": {
+                            "resource_pk": 1,
+                            "public_id": "mozilla-concrete-brick",
+                            "seller": "/generic/seller/8/",
+                            "external_id": "mozilla-concrete-brick",
+                            "resource_uri": "/generic/product/1/"
+                        },
+                        "uuid": "bt-b-cLt3FD",
+                        "seller": "/generic/seller/8/",
+                        "provider": 4,
+                        "type": 0,
+                        "status": 2,
+                        "buyer": "/generic/buyer/8/",
+                        "created": "2015-08-07T14:53:24",
+                        "currency": "USD",
+                        "amount": "10.00"
+                    },
+                    "next_billing_period_amount": "10.00",
+                    "paymethod":"/braintree/mozilla/paymethod/1/",
+                    "billing_period_end_date": "2015-09-06T00:00:00",
+                    "next_billing_date":"2015-09-06T00:00:00",
+                    "billing_period_start_date": "2015-08-07T00:00:00",
+                    "subscription": "/braintree/mozilla/subscription/1/"
+                }
+            ]
+        }
+
+    :status 200: transactions returned successfully
+
 Webhooks
 ~~~~~~~~
 
@@ -440,6 +499,8 @@ see the `Braintree documentation <https://developers.braintreepayments.com/javas
 
     This request and response is the same as Solitudes `webhook API`_.
 
+.. _`generic product object`: http://solitude.readthedocs.org/en/latest/topics/generic.html#product
+.. _`braintree transaction object`: http://solitude.readthedocs.org/en/latest/topics/braintree.html#get--braintree-mozilla-transaction--transaction%20id--
 .. _`payment method`: https://solitude.readthedocs.org/en/latest/topics/braintree.html#id2
 .. _`payment methods`: https://solitude.readthedocs.org/en/latest/topics/braintree.html#id2
 .. _`webhook API`: http://solitude.readthedocs.org/en/latest/topics/braintree.html#webhook

--- a/payments_service/braintree/tests/test_views/test_transactions.py
+++ b/payments_service/braintree/tests/test_views/test_transactions.py
@@ -1,0 +1,73 @@
+from django.core.urlresolvers import reverse
+
+import mock
+from nose.tools import eq_
+
+from payments_service.base.tests import AuthenticatedTestCase
+
+
+class TestGetTransactions(AuthenticatedTestCase):
+
+    def setUp(self):
+        super(TestGetTransactions, self).setUp()
+        self.transaction_uri = '/transaction/1234/'
+        self.seller_product_uri = '/product/1234/'
+        self.uri_resources = self.setup_uri_lookups()
+
+        self.api_transactions = [{
+            'transaction': self.transaction_uri,
+            'resource_pk': 1,
+        }]
+        self.solitude.braintree.mozilla.transaction.get.return_value = (
+            self.api_transactions
+        )
+
+        self.uri_resources[self.transaction_uri].get_object.return_value = {
+            'seller_product': self.seller_product_uri,
+        }
+
+        self.uri_resources[self.seller_product_uri].get_object.return_value = {
+        }
+
+    def setup_uri_lookups(self):
+        resources = {
+            self.transaction_uri: mock.Mock(),
+            self.seller_product_uri: mock.Mock(),
+        }
+
+        def get_api_object(uri):
+            res = resources.get(uri)
+            if not res:
+                raise ValueError('unknown uri {}'.format(uri))
+            return res
+
+        self.solitude.by_url.side_effect = get_api_object
+        return resources
+
+    def get(self):
+        return self.json(
+            self.client.get(reverse('braintree:transactions'))
+        )
+
+    def test_return_api_transactions(self):
+        res, data = self.get()
+        eq_(res.status_code, 200, res)
+        eq_(data['transactions'], self.api_transactions)
+
+    def test_only_get_user_transactions(self):
+        self.get()
+
+        get = self.solitude.braintree.mozilla.transaction.get
+        eq_(get.call_args[1]['transaction__buyer__uuid'],
+            self.buyer_uuid)
+
+    def test_get_nested_uri_results(self):
+        self.get()
+        # Currently, nested URIs will be fetched to expand the result set.
+        # For example, this URI would be fetched and its result inserted:
+        # {
+        #     "resource_pk": 1,
+        #     "transaction": "/transaction/123/",
+        # }
+        assert self.uri_resources[self.transaction_uri].get_object.called
+        assert self.uri_resources[self.seller_product_uri].get_object.called

--- a/payments_service/braintree/urls.py
+++ b/payments_service/braintree/urls.py
@@ -6,6 +6,7 @@ from .views.subscriptions import (
 from .views.token_generator import TokenGenerator
 from .views.paymethod import (BraintreePayMethod, DeleteBraintreePayMethod,
                               PayMethod)
+from .views.transactions import Transactions
 from .views.webhook import debug_email, Webhook
 
 
@@ -18,6 +19,8 @@ urlpatterns = patterns(
     url(r'^subscriptions/paymethod/change/$',
         ChangeSubscriptionPayMethod.as_view(),
         name='subscriptions.paymethod.change'),
+    url(r'^transactions/$', Transactions.as_view(),
+        name='transactions'),
     url(r'^token/generate/$', TokenGenerator.as_view(), name='token.generate'),
     url(r'^paymethod/$', BraintreePayMethod.as_view(), name='paymethod'),
     url(r'^paymethod/delete/$', DeleteBraintreePayMethod.as_view(),

--- a/payments_service/braintree/views/transactions.py
+++ b/payments_service/braintree/views/transactions.py
@@ -1,0 +1,19 @@
+from rest_framework.response import Response
+
+from payments_service.solitude import SolitudeAPIView
+
+
+class Transactions(SolitudeAPIView):
+    """
+    Deals with Braintree related transactions.
+    """
+    def get(self, request):
+        transactions = self.api.braintree.mozilla.transaction.get(
+            transaction__buyer__uuid=self.request.user.uuid,
+        )
+        return Response({
+            'transactions': self.expand_api_objects(
+                transactions,
+                [{'transaction': ['seller_product']}],
+            ),
+        }, status=200)


### PR DESCRIPTION
Supports https://github.com/mozilla/payments-ui/issues/279

This looks at some URIs in the Solitude results and makes additional GET requests to expand the URIs to objects. This seemed like a quick hacky way to get the right data but ultimately we should follow up with a patch to solitude that returns the right data.
