### PR TITLE
Create a recurring donation w/ email only, no auth (fixes #141)

### DIFF
--- a/docs/topics/api.rst
+++ b/docs/topics/api.rst
@@ -391,6 +391,22 @@ These endpoints allow you to work with Braintree plan subscriptions.
     To pay using a new credit card, submit ``pay_method_nonce``. To pay
     with a saved credit card, submit ``pay_method_uri``.
 
+    There are currently two types of subscriptions supported, which
+    vary the way this API endpoint can be used:
+
+    **service subscriptions**
+
+    - The user must be signed in.
+    - ``amount`` cannot be used because these types of subscriptions have a
+      fixed price.
+    - ``email`` cannot be used because the user is already signed in.
+
+    **recurring donations**
+
+    - The user doesn't have to be signed in.
+    - To subscribe a user without sign-in, pass in their ``email``.
+    - The recurring donation ``amount`` is customizable.
+
     **Request**
 
     :param string pay_method_nonce:
@@ -408,6 +424,12 @@ These endpoints allow you to work with Braintree plan subscriptions.
         Custom payment amount as a decimal string.
         This only applies to subscription plans that allow
         custom amounts such as recurring donations.
+    :param string email:
+        Email of the person who is subscribing to the plan.
+        This only applies to requests where the user has not already been
+        signed in. Not all plans can be subscribed anonymously like this.
+        For example, recurring donations can be created this way but
+        service subscriptions cannot.
 
     **Response**
 

--- a/payments_service/auth/__init__.py
+++ b/payments_service/auth/__init__.py
@@ -33,6 +33,7 @@ class SolitudeBuyer(AnonymousUser):
         return False
 
     def is_authenticated(self):
+        # TODO: maybe return False here for email-only buyers?
         return True
 
 

--- a/payments_service/base/tests/__init__.py
+++ b/payments_service/base/tests/__init__.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from django.conf import settings
 from django.conf.urls import patterns, url
@@ -157,6 +158,35 @@ fake_payments_config = {
         ]
     },
 }
+
+
+class FormTest(TestCase):
+    """
+    A mixin for tests directly against form objects.
+    """
+
+    def assert_form_error(self, errors, error_key, msg=None):
+        """
+        Make assertions about a form error
+
+        **errors**
+            The ``form.errors`` property
+        **error_key**
+            The field name or ``__all__`` error key
+        **msg=None**
+            An optional regular expression pattern that will be
+            used to check the error message.
+        """
+        assert error_key in errors, (
+            'error_key {} not in {}'.format(error_key, errors.as_text())
+        )
+        if msg:
+            actual_msg = ', '.join(e.message for e in
+                                   errors.as_data()[error_key])
+            assert re.match(msg, actual_msg), (
+                'error message "{}" did not match pattern "{}"'
+                .format(actual_msg, msg)
+            )
 
 
 class WithFakePaymentsConfig(TestCase):

--- a/payments_service/base/views.py
+++ b/payments_service/base/views.py
@@ -1,7 +1,37 @@
-from django.http import JsonResponse
+import logging
+
+from django.http import HttpResponseNotAllowed, JsonResponse
 
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView
+
+log = logging.getLogger(__name__)
+
+
+def composed_view(handlers):
+    """
+    Returns a Django view (for use in URL patterns) that delegates
+    processing to other view callables based on request method.
+
+    Example:
+
+        composed_view({'get': list_view, 'post': create_view})
+
+    You can already do this by implementing ``get``, ``post``, etc.
+    methods on a class based view but this is helpful for DRF view classes
+    since ther authentication scope is at the class level, not the method
+    level.
+    """
+
+    def delegate_request(request, *args, **kwargs):
+        handle_request = handlers.get(request.method.lower())
+        if not handle_request:
+            permitted_methods = handlers.keys()
+            return HttpResponseNotAllowed(permitted_methods)
+
+        return handle_request(request, *args, **kwargs)
+
+    return delegate_request
 
 
 class UnprotectedAPIView(APIView):

--- a/payments_service/braintree/tests/test_forms.py
+++ b/payments_service/braintree/tests/test_forms.py
@@ -1,13 +1,17 @@
+from django.core.exceptions import ObjectDoesNotExist
+
 import mock
+from nose.tools import eq_
 
 from payments_service.auth import SolitudeBuyer
+from payments_service.base.tests import WithFakePaymentsConfig
 
-from .test_views.test_subscriptions import SubscriptionTest
+from .test_views.test_subscriptions import ExistingSubscriptionTest
 from ..forms import (ChangeSubscriptionPayMethodForm,
-                     ManageSubscriptionForm, SaleForm)
+                     ManageSubscriptionForm, SaleForm, SubscriptionForm)
 
 
-class PaymentFormTest(SubscriptionTest):
+class PaymentFormTest(ExistingSubscriptionTest):
 
     def setUp(self):
         super(PaymentFormTest, self).setUp()
@@ -34,6 +38,124 @@ class PaymentFormTest(SubscriptionTest):
         if not expect_errors:
             assert form.is_valid(), form.errors.as_text()
         return form
+
+
+class TestSubscriptionForm(WithFakePaymentsConfig, PaymentFormTest):
+
+    def setUp(self):
+        super(TestSubscriptionForm, self).setUp()
+        self.pay_method_nonce = 'some-bt-pay-method-nonce'
+        self.plan_id = 'service-subscription'
+
+    def form_data(self):
+        return SubscriptionForm, {
+            'pay_method_nonce': self.pay_method_nonce,
+            'plan_id': self.plan_id,
+        }
+
+    def expect_non_existant_buyer(self):
+        getter = self.solitude.generic.buyer.get_object_or_404
+        getter.side_effect = ObjectDoesNotExist
+
+    def expect_existing_buyer(self, uuid='some-uuid',
+                              authenticated=False):
+        self.solitude.generic.buyer.get_object_or_404.return_value = {
+            'resource_pk': 1244,
+            'uuid': uuid,
+            'authenticated': authenticated,
+        }
+
+    def test_too_many_pay_methods(self):
+        form = self.submit(
+            expect_errors=True,
+            overrides=dict(pay_method_uri='/my/saved/paymethod',
+                           pay_method_nonce='some-nonce'),
+        )
+        assert '__all__' in form.errors, (
+            form.errors.as_text()
+        )
+
+    def test_missing_pay_method(self):
+        form = self.submit(
+            expect_errors=True,
+            overrides=dict(pay_method_uri=None,
+                           pay_method_nonce=None),
+        )
+        assert '__all__' in form.errors, (
+            form.errors.as_text()
+        )
+
+    def test_email_only_recurring_donation_creates_user(self):
+        self.expect_non_existant_buyer()
+        email = 'someone@somewhere.org'
+        self.solitude.generic.buyer.post.return_value = {
+            'uuid': 'created-uuid',
+            'resource_pk': 1234,
+        }
+
+        form = self.submit(
+            user=False,
+            overrides=dict(plan_id='org-recurring-donation',
+                           email=email))
+
+        assert self.solitude.generic.buyer.post.called
+        args = self.solitude.generic.buyer.post.call_args[0][0]
+        eq_(args['email'], email)
+        eq_(args['authenticated'], False)
+        assert args['uuid'].startswith('service:unauthenticated:'), (
+            args['uuid']
+        )
+        eq_(form.user.uuid, 'created-uuid')
+
+    def test_reuse_email_buyer_if_not_authenticated(self):
+        self.expect_existing_buyer(uuid='existing-uuid',
+                                   authenticated=False)
+        email = 'someone@somewhere.org'
+        form = self.submit(
+            user=False,
+            overrides=dict(plan_id='org-recurring-donation',
+                           email=email))
+        eq_(form.user.uuid, 'existing-uuid')
+        assert not self.solitude.generic.buyer.post.called
+
+    def test_cannot_reuse_email_buyer_if_they_were_authenticated(self):
+        self.expect_existing_buyer(authenticated=True)
+        form = self.submit(
+            expect_errors=True,
+            user=False,
+            overrides=dict(plan_id='org-recurring-donation',
+                           email='someone@somewhere.org'))
+        assert '__all__' in form.errors, (
+            form.errors.as_text()
+        )
+
+    def test_recurring_donation_requires_email(self):
+        form = self.submit(
+            expect_errors=True,
+            user=False,
+            overrides=dict(plan_id='org-recurring-donation'))
+        assert 'plan_id' in form.errors, (
+            form.errors.as_text()
+        )
+
+    def test_cannot_subscribe_to_an_unknown_plan(self):
+        form = self.submit(
+            expect_errors=True,
+            overrides=dict(plan_id='non-existant-plan'))
+        assert 'plan_id' in form.errors, (
+            form.errors.as_text()
+        )
+
+    def test_email_only_user_cannot_subscribe_to_an_auth_protected_plan(self):
+        form = self.submit(
+            expect_errors=True,
+            user=False,
+            overrides=dict(plan_id='service-subscription',
+                           email='someone@somewhere.org'))
+        assert 'plan_id' in form.errors, (
+            form.errors.as_text()
+        )
+        assert not self.solitude.generic.buyer.post.called
 
 
 class TestManageSubscriptionForm(PaymentFormTest):

--- a/payments_service/braintree/urls.py
+++ b/payments_service/braintree/urls.py
@@ -1,7 +1,10 @@
 from django.conf.urls import patterns, url
 
+from payments_service.base.views import composed_view
+
 from .views.subscriptions import (
-    CancelSubscription, ChangeSubscriptionPayMethod, Subscriptions
+    CancelSubscription, ChangeSubscriptionPayMethod, CreateSubscriptions,
+    RetrieveSubscriptions,
 )
 from .views.token_generator import TokenGenerator
 from .views.paymethod import (BraintreePayMethod, DeleteBraintreePayMethod,
@@ -14,8 +17,13 @@ from .views.webhook import debug_email, Webhook
 urlpatterns = patterns(
     '',
     url(r'^sale/$', Sale.as_view(), name='sale'),
-    url(r'^subscriptions/$', Subscriptions.as_view(),
-        name='subscriptions'),
+    url(r'^subscriptions/$',
+        composed_view({
+            'get': RetrieveSubscriptions.as_view(),
+            'post': CreateSubscriptions.as_view(),
+            # TODO: I think I need 'options' for CORS. This is a note to self
+            # so I can test it before merging.
+        }), name='subscriptions'),
     url(r'^subscriptions/cancel/$', CancelSubscription.as_view(),
         name='subscriptions.cancel'),
     url(r'^subscriptions/paymethod/change/$',

--- a/payments_service/braintree/urls.py
+++ b/payments_service/braintree/urls.py
@@ -21,8 +21,6 @@ urlpatterns = patterns(
         composed_view({
             'get': RetrieveSubscriptions.as_view(),
             'post': CreateSubscriptions.as_view(),
-            # TODO: I think I need 'options' for CORS. This is a note to self
-            # so I can test it before merging.
         }), name='subscriptions'),
     url(r'^subscriptions/cancel/$', CancelSubscription.as_view(),
         name='subscriptions.cancel'),

--- a/payments_service/braintree/views/webhook.py
+++ b/payments_service/braintree/views/webhook.py
@@ -6,8 +6,8 @@ from django.http import HttpResponse
 from django.template import Context
 from django.template.loader import get_template
 
+import payments_config
 from dateutil.parser import parse as parse_date
-from payments_config import products
 from premailer import Premailer
 from rest_framework.renderers import BaseRenderer
 from rest_framework.response import Response
@@ -111,7 +111,9 @@ class Webhook(UnprotectedAPIView):
                  .format(b=result['mozilla']['buyer'],
                          k=notice_kind))
 
-        product = products[result['mozilla']['product']['public_id']]
+        product = payments_config.products[
+            result['mozilla']['product']['public_id']
+        ]
         bt_trans = result['mozilla']['transaction']['braintree']
         moz_trans = result['mozilla']['transaction']['generic']
 
@@ -182,7 +184,9 @@ def debug_email(request):
         )
     moz = api.by_url(bt['transaction']).get()
     method = api.by_url(bt['paymethod']).get()
-    product = products[api.by_url(moz['seller_product']).get()['public_id']]
+    product = payments_config.products[
+        api.by_url(moz['seller_product']).get()['public_id']
+    ]
 
     # Render the HTML.
     data = webhook.build_context(bt, moz, method, product, kind)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -56,8 +56,8 @@ oauthlib==0.7.2
 # sha256: PWMqzIaGoHullsTeJTJxG3s2D4jECiiIE5WqIUn718g
 oauth2==1.5.211
 
-# sha256: ogcDHY1RGrz8PN7rJ5R0JhXujEZasdbDXqJNwRyWr5w
-payments-config==0.0.12
+# sha256: AMP3ijaKeViemJNzzEDli8dWcSlgdA9GjcUvX82IdpM
+payments-config==0.0.13
 
 # sha256: mG9LKd89WZeR-lvFXoRs6fY-q8fm8ZsrNNb0mPCdqQ8
 pyasn1==0.1.8


### PR DESCRIPTION
Fixes https://github.com/mozilla/payments-service/issues/141
