### PR TITLE
Prevent subscribing with email while signed in (fixes mozilla/payments-ui#378)

### DIFF
--- a/payments_service/braintree/forms.py
+++ b/payments_service/braintree/forms.py
@@ -55,11 +55,18 @@ class SubscriptionForm(forms.Form):
                 forms.ValidationError('Unrecoginized plan_id: {}'
                                       .format(plan_id)))
 
-        if not self.user:
+        email = cleaned_data.get('email')
+        if self.user:
+            if email:
+                return self.add_error(
+                    'email',
+                    forms.ValidationError(
+                        'Cannot subscribe with an email address while the '
+                        'user is signed in'))
+        else:
             # If no user has been signed in, we will assume the subsciption
             # plan supports email-only subscriptions and raise the appropriate
             # errors if not.
-            email = cleaned_data.get('email')
             if not email:
                 return self.add_error(
                     'plan_id',

--- a/payments_service/braintree/tests/test_forms.py
+++ b/payments_service/braintree/tests/test_forms.py
@@ -126,6 +126,17 @@ class TestSubscriptionForm(WithFakePaymentsConfig, PaymentFormTest):
         eq_(form.user.uuid, 'created-uuid')
         self.set_up_braintree_customer.assert_called_with(buyer)
 
+    def test_cannot_subscribe_with_email_when_signed_in(self):
+        # Submit the form with a signed-in user (the default).
+        form = self.submit(
+            expect_errors=True,
+            overrides={'plan_id': 'org-recurring-donation',
+                       'email': 'someone@somewhere.org'})
+        self.assert_form_error(
+            form.errors, 'email',
+            msg='Cannot subscribe with an email address while the '
+                'user is signed in')
+
     def test_recurring_donation_requires_email(self):
         form = self.submit(
             expect_errors=True,


### PR DESCRIPTION
Fixes https://github.com/mozilla/payments-ui/issues/378

Here's the current problem:
- the UI does not know that a user might be signed in on the server (via cookie)
- the UI will allow an anonymous recurring donation using a custom email
- the API (before this patch) would happily accept this donation but associate it with the currently signed in user, not that of the submitted email address

In lieu of a UI fix, this patch raises a form error explaining that you can't make an anonymous donation with an email while signed in. A proper (future) UI fix is probably to hit some kind of API endpoint asking "is this user signed in?" and, if so, fetching their email address. The UI could then pre-populate the email address in the donation form.
